### PR TITLE
USER 101 instead of postgres, for pod security policy verification

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,4 +10,4 @@ RUN chown -R postgres:postgres /bin && \
     chown postgres:postgres /launch.sh && \
     sed -i '10 a rm /etc/supervisor/conf.d/cron.conf' /launch.sh
 
-USER postgres
+USER 101


### PR DESCRIPTION
To avoid:
Error: container has runAsNonRoot and image has non-numeric user (postgres), cannot verify user is non-root